### PR TITLE
Removed jQuery dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ QUnit.notifications = function(options) {
     });
 
     window.addEventListener('load', function() {
-      var toolbar      = $('#qunit-testrunner-toolbar')[0];
+      var toolbar      = document.getElementById('qunit-testrunner-toolbar');
       var notification = document.createElement( "input" );
 
       notification.type = "checkbox";


### PR DESCRIPTION
QUnit runs without jQuery, therefore qunit-notifications shouldn't assume jQuery exists. 
