### PR TITLE
Fix URL link after checkbox click

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,10 +57,10 @@ QUnit.notifications = function(options) {
       notification.addEventListener('click', function(event) {
         if (event.target.checked) {
           window.Notification.requestPermission(function(status) {
-            window.location = QUnit.url({notification: true});
+            window.location = QUnit.url({notifications: true});
           });
         } else {
-          window.location = QUnit.url({notification: undefined});
+          window.location = QUnit.url({notifications: undefined});
         }
       }, false);
       toolbar.appendChild(notification);


### PR DESCRIPTION
When the user clicks the notification checkbox it adds a `notification=true` to the URL query params. However the code looks for `notifications` (plural) as the query params switch. These two should be in sync.