### PR TITLE
Fix behavior on Notifications permissions

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ QUnit.notifications = function(options) {
           disableCheckbox = function() {
             notification.checked = false;
             notification.disabled = true;
-            label.style.textDecoration = "line-through";
+            label.style.opacity = 0.5;
             label.title = notification.title = "Note: Notifications have been " +
               "disabled in this browser.";
           };

--- a/tests/requirements.test.js
+++ b/tests/requirements.test.js
@@ -1,32 +1,38 @@
 (function() {
   "use strict";
 
-  var iframe;
+  var iframeGrant,
+      iframeDeny,
+      iframeGranted,
+      iframeDenied;
 
   QUnit.module("Requirements", {
     beforeEach: function(assert) {
-      iframe = QUnit.addExampleSuite(assert, "stubs/empty.html?mocks");
+      iframeGrant = QUnit.addExampleSuite(assert, "stubs/empty.html?mocks=grant");
+      iframeDeny = QUnit.addExampleSuite(assert, "stubs/empty.html?mocks=deny");
+      iframeGranted = QUnit.addExampleSuite(assert, "stubs/empty.html?mocks=granted");
+      iframeDenied = QUnit.addExampleSuite(assert, "stubs/empty.html?mocks=denied");
     }
   });
 
   QUnit.test("Browser should support HTML5 notifications", function(assert) {
     assert.expect(2);
     assert.ok(
-      "Notification" in iframe.contentWindow,
+      "Notification" in iframeGrant.contentWindow,
       "window object should have a \"Notification\" member"
     );
     assert.strictEqual(
-      typeof iframe.contentWindow.Notification,
+      typeof iframeGrant.contentWindow.Notification,
       "function",
       "window.Notification should be a function"
     );
   });
 
-  QUnit.test("Notification mock should grant permission", function(assert) {
+  QUnit.test("Notification mock 'grant' should grant permission", function(assert) {
     assert.expect(4);
 
     assert.strictEqual(
-      iframe.contentWindow.Notification.permission,
+      iframeGrant.contentWindow.Notification.permission,
       "default",
       "Notification.permission should be set to \"default\" by default"
     );
@@ -34,7 +40,7 @@
     var permissionUpdated = false,
         newPermission = null;
 
-    iframe.contentWindow.Notification.requestPermission(function(permission) {
+    iframeGrant.contentWindow.Notification.requestPermission(function(permission) {
       permissionUpdated = true;
       newPermission = permission;
     });
@@ -47,17 +53,66 @@
       "New permission should be \"granted\""
     );
     assert.strictEqual(
-      iframe.contentWindow.Notification.permission,
+      iframeGrant.contentWindow.Notification.permission,
       "granted",
       "Notification.permission should be updated to \"granted\""
+    );
+  });
+
+  QUnit.test("Notification mock 'deny' should deny permission", function(assert) {
+    assert.expect(4);
+
+    assert.strictEqual(
+      iframeDeny.contentWindow.Notification.permission,
+      "default",
+      "Notification.permission should be set to \"default\" by default"
+    );
+
+    var permissionUpdated = false,
+        newPermission = null;
+
+    iframeDeny.contentWindow.Notification.requestPermission(function(permission) {
+      permissionUpdated = true;
+      newPermission = permission;
+    });
+    assert.ok(permissionUpdated,
+      "Permission should be denied synchronously"
+    );
+    assert.strictEqual(
+      newPermission,
+      "denied",
+      "New permission should be \"denied\""
+    );
+    assert.strictEqual(
+      iframeDeny.contentWindow.Notification.permission,
+      "denied",
+      "Notification.permission should be updated to \"denied\""
+    );
+  });
+
+  QUnit.test("Notification mock 'granted' should have permission granted", function(assert) {
+    assert.expect(1);
+    assert.strictEqual(
+      iframeGranted.contentWindow.Notification.permission,
+      "granted",
+      "Notification.permission should be set to \"granted\" by default"
+    );
+  });
+
+  QUnit.test("Notification mock 'denied' should have permission denied", function(assert) {
+    assert.expect(1);
+    assert.strictEqual(
+      iframeDenied.contentWindow.Notification.permission,
+      "denied",
+      "Notification.permission should be set to \"denied\" by default"
     );
   });
 
   QUnit.test("Notification mock should hold a Promise object", function(assert) {
     assert.expect(3);
 
-    var notification1 = new iframe.contentWindow.Notification("NOTIFICATION_TO_CLOSE_1"),
-        notification2 = new iframe.contentWindow.Notification("NOTIFICATION_TO_CLOSE_2"),
+    var notification1 = new iframeGrant.contentWindow.Notification("NOTIFICATION_TO_CLOSE_1"),
+        notification2 = new iframeGrant.contentWindow.Notification("NOTIFICATION_TO_CLOSE_2"),
         done = assert.async(),
         doneAll = assert.async();
 
@@ -74,12 +129,12 @@
       done();
     });
 
-    iframe.contentWindow.Notification.waitForAllClosed().then(function() {
+    iframeGrant.contentWindow.Notification.waitForAllClosed().then(function() {
       assert.ok(
         true,
         "Notification.waitForAllClosed promise should be resolved one all notifications are closed"
       );
-      iframe.updateCodeCoverage();
+      iframeGrant.updateCodeCoverage();
       doneAll();
     });
 
@@ -91,36 +146,36 @@
   QUnit.test("Sinon.JS should be able to spy notifications", function(assert) {
     assert.expect(7);
 
-    iframe.contentWindow.Notification.requestPermission();
-    assert.strictEqual(iframe.contentWindow.Notification.requestPermission.callCount, 1,
+    iframeGrant.contentWindow.Notification.requestPermission();
+    assert.strictEqual(iframeGrant.contentWindow.Notification.requestPermission.callCount, 1,
       "Notification.requestPermission should have been called once"
     );
 
-    iframe.contentWindow.Notification("NOTIFICATION_WITHOUT_NEW");
+    iframeGrant.contentWindow.Notification("NOTIFICATION_WITHOUT_NEW");
     assert.ok(
-      iframe.contentWindow.Notification.calledOnce,
+      iframeGrant.contentWindow.Notification.calledOnce,
       "Notification should have been called once"
     );
     assert.ok(
-      !iframe.contentWindow.Notification.calledWithNew(),
+      !iframeGrant.contentWindow.Notification.calledWithNew(),
       "Notification should not have been called with \"new\" keyword"
     );
     assert.ok(
-      iframe.contentWindow.Notification.calledWithExactly("NOTIFICATION_WITHOUT_NEW"),
+      iframeGrant.contentWindow.Notification.calledWithExactly("NOTIFICATION_WITHOUT_NEW"),
       "Notification should have been called with \"NOTIFICATION_WITHOUT_NEW\" argument"
     );
 
-    new iframe.contentWindow.Notification("NOTIFICATION_WITH_NEW");
+    new iframeGrant.contentWindow.Notification("NOTIFICATION_WITH_NEW");
     assert.ok(
-      iframe.contentWindow.Notification.calledTwice,
+      iframeGrant.contentWindow.Notification.calledTwice,
       "Notification should have been called twice now"
     );
     assert.ok(
-      iframe.contentWindow.Notification.calledWithNew(),
+      iframeGrant.contentWindow.Notification.calledWithNew(),
       "Notification should have been called with \"new\" keyword"
     );
     assert.ok(
-      iframe.contentWindow.Notification.calledWithExactly("NOTIFICATION_WITH_NEW"),
+      iframeGrant.contentWindow.Notification.calledWithExactly("NOTIFICATION_WITH_NEW"),
       "Notification should have been called with \"NOTIFICATION_WITH_NEW\" argument"
     );
   });

--- a/tests/stubs/mocks.js
+++ b/tests/stubs/mocks.js
@@ -34,20 +34,43 @@
     return RSVP.allSettled(NotificationMock.closePromises);
   },
 
-  NotificationMock.permission = "default";
-
   NotificationMock.requestPermission = function requestPermission(callback) {
-    this.permission = "granted";
+    this.permission = this.permissionToGrant;
     callback && callback(this.permission);
   };
 
   QUnit.config.urlConfig.push({
     id: "mocks",
     label: "Mocks",
-    tooltip: "Mock notifications"
+    tooltip: "Mock notifications",
+    value: {
+      grant: "Will grant",
+      deny: "Will deny",
+      granted: "Already granted",
+      denied: "Already denied"
+    }
   });
 
   if (QUnit.urlParams.mocks) {
+
+    switch (QUnit.urlParams.mocks) {
+      case "grant":
+        NotificationMock.permission = "default";
+        NotificationMock.permissionToGrant = "granted";
+        break;
+      case "deny":
+        NotificationMock.permission = "default";
+        NotificationMock.permissionToGrant = "denied";
+        break;
+      case "granted":
+        NotificationMock.permission = "granted";
+        NotificationMock.permissionToGrant = "granted";
+        break;
+      case "denied":
+        NotificationMock.permission = "denied";
+        NotificationMock.permissionToGrant = "denied";
+        break;
+    }
 
     // Replace native Notification with mock object
     // We can't use sinon.stub() here, because window.Notification may not exist

--- a/tests/toolbar.test.js
+++ b/tests/toolbar.test.js
@@ -1,19 +1,29 @@
 (function() {
   "use strict";
 
-  var iframeDisabled, iframeEnabled;
+  var iframeDisabledGrant,
+      iframeDisabledDeny,
+      iframeDisabledGranted,
+      iframeDisabledDenied,
+      iframeEnabled;
 
   QUnit.module("Toolbar", {
     beforeEach: function(assert) {
-      iframeDisabled = QUnit.addExampleSuite(assert, "stubs/success.html?mocks");
-      iframeEnabled = QUnit.addExampleSuite(assert, "stubs/success.html?mocks&notifications");
+      iframeDisabledGrant = QUnit.addExampleSuite(assert, "stubs/success.html?mocks=grant");
+      iframeDisabledDeny = QUnit.addExampleSuite(assert, "stubs/success.html?mocks=deny");
+      iframeDisabledGranted = QUnit.addExampleSuite(assert, "stubs/success.html?mocks=granted");
+      iframeDisabledDenied = QUnit.addExampleSuite(assert, "stubs/success.html?mocks=denied");
+      iframeEnabled = QUnit.addExampleSuite(
+        assert,
+        "stubs/success.html?mocks=granted&notifications"
+      );
     }
   });
 
   QUnit.test("A \"Notifications\" checkbox should appear in the toolbar", function(assert) {
     assert.expect(2);
     assert.strictEqual(
-      iframeDisabled.contentDocument.getElementById("qunit-notifications").nodeName,
+      iframeDisabledGrant.contentDocument.getElementById("qunit-notifications").nodeName,
       "INPUT",
       "Checkbox #qunit-notifications should be inserted into the enabled page"
     );
@@ -25,35 +35,120 @@
   });
 
   QUnit.test("Checking \"Notifications\" should enable QUnit Notifications", function(assert) {
-    assert.expect(4);
-    iframeDisabled.contentDocument.getElementById("qunit-notifications").click();
-    assert.ok(
-      iframeDisabled.contentWindow.Notification.requestPermission.calledOnce,
-      "window.Notification.requestPermission should be called once"
-    );
-    iframeDisabled.updateCodeCoverage();
+    assert.expect(3);
+    iframeDisabledGrant.contentDocument.getElementById("qunit-notifications").click();
+    iframeDisabledGrant.updateCodeCoverage();
 
     var done = assert.async();
-    iframeDisabled.addEventListener("load", function() {
-      iframeDisabled.contentWindow.QUnit.done(function() {
+    iframeDisabledGrant.addEventListener("load", function() {
+      iframeDisabledGrant.contentWindow.QUnit.done(function() {
         assert.strictEqual(
-          iframeDisabled.contentWindow.location.search,
-          "?mocks&notifications",
-          "URL query string should be ?mocks&notifications"
+          iframeDisabledGrant.contentWindow.location.search,
+          "?mocks=grant&notifications",
+          "URL query string should be ?mocks=grant&notifications"
         );
         assert.strictEqual(
-          iframeDisabled.contentWindow.QUnit.urlParams.notifications,
+          iframeDisabledGrant.contentWindow.QUnit.urlParams.notifications,
           true,
           "QUnit.urlParams.notifications should be true"
         );
         assert.ok(
-          iframeDisabled.contentWindow.Notification.calledOnce,
+          iframeDisabledGrant.contentWindow.Notification.calledOnce,
           "window.Notification should be called once"
         );
-        iframeDisabled.updateCodeCoverage();
+        iframeDisabledGrant.updateCodeCoverage();
         done();
       });
     });
+  });
+
+  QUnit.test("Checking \"Notifications\" should not enable QUnit Notifications" +
+      " if user denies permission", function(assert) {
+    assert.expect(4);
+    iframeDisabledDeny.contentDocument.getElementById("qunit-notifications").click();
+    iframeDisabledDeny.updateCodeCoverage();
+
+    var done = assert.async(),
+        reloaded = false;
+
+    iframeDisabledDeny.addEventListener("load", function() {
+      reloaded = true;
+    });
+
+    setTimeout(function() {
+      assert.ok(!reloaded, "Window should not reload");
+      assert.strictEqual(
+        iframeDisabledDeny.contentWindow.location.search,
+        "?mocks=deny",
+        "URL query string should remain ?mocks=deny"
+      );
+      assert.strictEqual(
+        iframeDisabledDeny.contentWindow.QUnit.urlParams.notifications,
+        undefined,
+        "QUnit.urlParams.notifications should be undefined"
+      );
+      assert.ok(
+        !iframeDisabledDeny.contentWindow.Notification.calledOnce,
+        "window.Notification should not be called"
+      );
+      iframeDisabledDeny.updateCodeCoverage();
+      done();
+    }, 1000); // let time to reload if it does
+
+  });
+
+  QUnit.test("Checking \"Notifications\" should ask for permission" +
+      " when Notification.permission does not exist", function(assert) {
+    assert.expect(1);
+    delete iframeDisabledGrant.contentWindow.Notification.permission;
+    iframeDisabledGrant.contentDocument.getElementById("qunit-notifications").click();
+    assert.ok(
+      iframeDisabledGrant.contentWindow.Notification.requestPermission.calledOnce,
+      "window.Notification.requestPermission should be called once"
+    );
+    iframeDisabledGrant.updateCodeCoverage();
+  });
+
+  QUnit.test("Checking \"Notifications\" should ask for permission" +
+      " when Notification.permission is \"default\"", function(assert) {
+    assert.expect(1);
+    iframeDisabledGrant.contentDocument.getElementById("qunit-notifications").click();
+    assert.ok(
+      iframeDisabledGrant.contentWindow.Notification.requestPermission.calledOnce,
+      "window.Notification.requestPermission should be called once"
+    );
+    iframeDisabledGrant.updateCodeCoverage();
+  });
+
+  QUnit.test("Checking \"Notifications\" should not ask for permission" +
+      " when Notification.permission is \"granted\"", function(assert) {
+    assert.expect(1);
+    iframeDisabledGranted.contentDocument.getElementById("qunit-notifications").click();
+    assert.ok(
+      !iframeDisabledGranted.contentWindow.Notification.requestPermission.calledOnce,
+      "window.Notification.requestPermission should not be called once"
+    );
+    iframeDisabledGranted.updateCodeCoverage();
+  });
+
+  QUnit.test("Checking \"Notifications\" should not ask for permission" +
+      " when Notification.permission is \"denied\"", function(assert) {
+    assert.expect(1);
+    iframeDisabledDenied.contentDocument.getElementById("qunit-notifications").click();
+    assert.ok(
+      !iframeDisabledDenied.contentWindow.Notification.requestPermission.calledOnce,
+      "window.Notification.requestPermission should not be called once"
+    );
+    iframeDisabledDenied.updateCodeCoverage();
+  });
+
+  QUnit.test("\"Notifications\" checkbox should be disabled" +
+      " when Notification.permission is \"denied\"", function(assert) {
+    assert.expect(1);
+    assert.ok(
+      iframeDisabledDenied.contentDocument.getElementById("qunit-notifications").disabled,
+      "\"Notifications\" checkbox should be disabled"
+    );
   });
 
   QUnit.test("Unchecking \"Notifications\" should disable QUnit Notifications", function(assert) {
@@ -70,8 +165,8 @@
       iframeEnabled.contentWindow.QUnit.done(function() {
         assert.strictEqual(
           iframeEnabled.contentWindow.location.search,
-          "?mocks",
-          "URL query string should be ?mocks"
+          "?mocks=granted",
+          "URL query string should be ?mocks=granted"
         );
         assert.strictEqual(
           iframeEnabled.contentWindow.QUnit.urlParams.notifications,


### PR DESCRIPTION
Permissions are not respected accordingly:
- [x] if user has granted Notifications permission in the past, it should not grant it again
- [x] if user had denied Notifications permission in the past, notification checkbox should be disabled*
- [x] while user enables notifications for the first time but denies Notifications permission, it should stay disabled (and checkbox should be disabled)
- [x] we may need to add some sort of message, tooltip or indication explaining why it's been disabled

Please read [MDN - Notification.permission](https://developer.mozilla.org/en-US/docs/Web/API/Notification.permission) for technical details.