### PR TITLE
Avoid assuming info about the testing DOM.

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,8 +72,10 @@ QUnit.notifications = function( options ) {
     } );
 
     QUnit.begin( function() {
-      var toolbar      = document.getElementById( "qunit-testrunner-toolbar" ),
-          notification = document.createElement( "input" ),
+      var toolbar      = document.getElementById( "qunit-testrunner-toolbar" );
+      if ( !toolbar ) { return; }
+
+      var notification = document.createElement( "input" ),
           label        = document.createElement( "label" ),
           disableCheckbox = function() {
             notification.checked = false;


### PR DESCRIPTION
Qunit runs just fine even if it doesn't have a DOM container. qunit-notifications presently requires a certain DOM element or it blows up. This removes that unnecessary dependency.