### PR TITLE
Don't install bower devDependencies automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "homepage": "https://github.com/dockyard/qunit-notifications",
   "version": "0.1.0",
   "scripts": {
-    "install": "bower install",
     "lint": "jshint --reporter node_modules/jshint-stylish/stylish.js .",
     "codestyle": "jscs .",
     "karma": "./node_modules/karma/bin/karma start",


### PR DESCRIPTION
Currently, if you `npm install qunit-notifications`, it will also install the `devDependencies` listed in `bower.json`. This is obviously not ideal, so I removed the script from `package.json` that enables this. I could also rename it if desirable.