### PR TITLE
Don't publish extra file

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "homepage": "https://github.com/dockyard/qunit-notifications",
   "version": "0.1.1",
+  "files": ["index.js"],
   "scripts": {
     "lint": "jshint --reporter node_modules/jshint-stylish/stylish.js .",
     "codestyle": "jscs .",


### PR DESCRIPTION
* add package.json.files whitelist, containing only `index.js` (which appears to be the one file that we need to distribute)