### PR TITLE
Fix checkbox container for qunit@2

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,6 +75,11 @@ QUnit.notifications = function( options ) {
       var toolbar      = document.getElementById( "qunit-testrunner-toolbar" );
       if ( !toolbar ) { return; }
 
+      var checkboxContainer = toolbar.querySelector(".qunit-url-config");
+      if (!checkboxContainer) { // qunit < 2
+        checkboxContainer = toolbar;
+      }
+
       var notification = document.createElement( "input" ),
           label        = document.createElement( "label" ),
           disableCheckbox = function() {
@@ -117,8 +122,7 @@ QUnit.notifications = function( options ) {
         }
       }, false );
 
-      toolbar.appendChild( notification );
-      toolbar.appendChild( label );
+      checkboxContainer.appendChild( label );
    } );
   }
 };


### PR DESCRIPTION
"Notifications" checkbox is not groupped with another `qunit-url-config` checkboxes in `qunit@2`:
![qunit-notifications-checkbox](https://cloud.githubusercontent.com/assets/875361/21205990/ea288b5e-c267-11e6-98f9-6f74c47fadca.png)

I've tried to fix it here